### PR TITLE
Bump `aeson` upper bound

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -6,7 +6,7 @@ extra-source-files:
 github: joneshf/rollbar-hs
 library:
   dependencies:
-    - aeson >= 1.0 && < 1.3
+    - aeson >= 1.0 && < 1.5
     - base >= 4.9 && < 5
     - bytestring >= 0.10 && < 0.11
     - case-insensitive >= 1.2 && < 1.3


### PR DESCRIPTION
Per https://github.com/commercialhaskell/stackage/issues/3393,
`aeson` is out of bounds.

To get back into stackage nightly, we need to be compatible with it.