### PR TITLE
Relax upper bound for `network` to 2.8

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,7 @@ library:
     - http-client >= 0.5 && < 0.6
     - http-conduit >= 2.2 && < 2.4
     - http-types >= 0.9 && < 0.13
-    - network >= 2.6 && < 2.7
+    - network >= 2.6 && < 2.8
     - text >= 1.2 && < 1.3
     - time >= 1.6 && < 1.9
     - unordered-containers >= 0.2 && < 0.3


### PR DESCRIPTION
The changes from 2.6 to 2.7 don't seem to affect what we're using.